### PR TITLE
ci: add default working directory to all jobs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Backend
 
     steps:
       # Step 1: Check out the code
@@ -22,29 +25,22 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
+          cache-dependency-path: Backend/go.sum
 
       # Step 3: Install dependencies
       - name: Install dependencies
-        run: |
-          cd Backend
-          go mod tidy
+        run: go mod tidy
 
       # Step 4: Run tests and generate coverage
       - name: Run tests
-        run: |
-          cd Backend
-          go test -coverprofile=coverage.out ./...
+        run: go test -coverprofile=coverage.out ./...
 
       # Step 5: Install goveralls
       - name: Install goveralls
-        run: |
-          cd Backend
-          go install github.com/mattn/goveralls@latest
+        run: go install github.com/mattn/goveralls@latest
 
       # Step 6: Send coverage to Coveralls
       - name: Send coverage to Coveralls
-        run: |
-          cd Backend
-          goveralls -coverprofile=coverage.out -service=github -repotoken ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: goveralls -coverprofile=coverage.out -service=github -repotoken ${{ secrets.COVERALLS_REPO_TOKEN }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,35 +3,32 @@ name: Frontend CI
 on:
   push:
     paths:
-      - 'frontend/**'
+      - "Frontend/**"
   pull_request:
     paths:
-      - 'frontend/**'
+      - "Frontend/**"
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Frontend
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18' # Specify your Node.js version
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18" # Specify your Node.js version
 
-    - name: Install dependencies
-      run: |
-        cd frontend
-        npm install
+      - name: Install dependencies
+        run: npm install
 
-    - name: Run tests
-      run: |
-        cd frontend
-        npm test
+      - name: Run tests
+        run: npm test
 
-    - name: Build application
-      run: |
-        cd frontend
-        npm run build
+      - name: Build application
+        run: npm run build


### PR DESCRIPTION
- **Added default working directories to all jobs:** All jobs now have default working directories, eliminating the need for `cd` commands within each step.

- **Added cache-dependency-path input**: Since the `go.sum` file is located in a subdirectory, I've added a custom cache-dependency-path input to the setup-go action. This ensures that the cache key accurately reflects the project's dependencies, leading to more effective cache utilization and faster build times.
